### PR TITLE
Fix 2 errors.

### DIFF
--- a/Editor/BuildHistory/BuildEntry.cs
+++ b/Editor/BuildHistory/BuildEntry.cs
@@ -61,7 +61,11 @@ namespace FronkonGames.Tools.BuildHistory
         name = BuildData.GetKeyName(buildIndex);
         buildStartedAt = summary.buildStartedAt;
         platform = summary.platform;
-        totalFiles = report.files.Length; 
+#if UNITY_2022_1_OR_NEWER
+        totalFiles = report.GetFiles().Length; 
+#else
+        totalFiles = report.files.Length;
+#endif
         totalSize = summary.totalSize;
         totalSeconds = (int)summary.totalTime.TotalSeconds;
         totalErrors = summary.totalErrors;

--- a/Editor/BuildHistory/FronkonGames.Tools.BuildHistory.Editor.asmdef
+++ b/Editor/BuildHistory/FronkonGames.Tools.BuildHistory.Editor.asmdef
@@ -4,7 +4,9 @@
   [
   ],
   "optionalUnityReferences": [],
-  "includePlatforms": [],
+  "includePlatforms": [
+    "Editor"
+  ],
   "excludePlatforms": [],
   "allowUnsafeCode": false,
   "overrideReferences": false,


### PR DESCRIPTION
1. Fix errors that occur with Unity 2022
```
Build-History\Editor\BuildHistory\BuildEntry.cs(64,22): error CS0619: 'BuildReport.files' is obsolete: 'Use GetFiles() method instead (UnityUpgradable) -> GetFiles()'
```

2. Errors that occur during build.

```
Build-History\Editor\BuildHistory\BuildData.cs(19,19): error CS0234: The type or namespace name 'Build' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)
Build-History\Editor\BuildHistory\BuildEntry.cs(19,19): error CS0234: The type or namespace name 'Build' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)
Build-History\Editor\BuildHistory\BuildHistoryEditor.cs(23,19): error CS0234: The type or namespace name 'Build' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)
Build-History\Editor\BuildHistory\BuildHook.cs(18,19): error CS0234: The type or namespace name 'Build' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)
Build-History\Editor\BuildHistory\BuildHook.cs(19,19): error CS0234: The type or namespace name 'Build' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)
Build-History\Editor\BuildHistory\BuildHook.cs(24,28): error CS0246: The type or namespace name 'IPostprocessBuildWithReport' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildEntry.cs(95,20): error CS0246: The type or namespace name 'BuildTarget' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildEntry.cs(102,20): error CS0246: The type or namespace name 'BuildResult' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildEntry.cs(54,23): error CS0246: The type or namespace name 'BuildReport' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildHook.cs(30,36): error CS0246: The type or namespace name 'BuildReport' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildEntry.cs(33,12): error CS0246: The type or namespace name 'BuildTarget' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildHook.cs(26,26): error CS0246: The type or namespace name 'BuildReport' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildData.cs(47,29): error CS0246: The type or namespace name 'BuildReport' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildHistoryEditor.cs(28,37): error CS0246: The type or namespace name 'EditorWindow' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildEntry.cs(51,12): error CS0246: The type or namespace name 'BuildResult' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildPlatform.cs(73,49): error CS0246: The type or namespace name 'BuildTarget' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\LineChart.cs(77,20): error CS0246: The type or namespace name 'EditorWindow' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\LineChart.cs(81,20): error CS0246: The type or namespace name 'EditorWindow' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildHistoryEditor.cs(499,32): error CS0246: The type or namespace name 'BuildReport' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildHistoryEditor.cs(77,6): error CS0246: The type or namespace name 'MenuItemAttribute' could not be found (are you missing a using directive or an assembly reference?)
Build-History\Editor\BuildHistory\BuildHistoryEditor.cs(77,6): error CS0246: The type or namespace name 'MenuItem' could not be found (are you missing a using directive or an assembly reference?)
Error building Player because scripts had compiler errors
```